### PR TITLE
Card Games: rephrase the instructions for Task 6

### DIFF
--- a/exercises/concept/card-games/.docs/instructions.md
+++ b/exercises/concept/card-games/.docs/instructions.md
@@ -92,10 +92,10 @@ False
 
 ## 6. More Averaging Techniques
 
-Intrigued by the results of her averaging experiment, Elyse is wondering if taking the average of _even_ values versus the average of _odd_ values would give the same results.
+Intrigued by the results of her averaging experiment, Elyse is wondering if taking the average of the cards at the _even_ positions versus the average of the cards at the _odd_ positions would give the same results.
  Time for another test function!
 
-Implement a function `average_even_is_average_odd(<hand>)` that returns a Boolean indicating if the average of the even valued cards is the same as the average of the odd valued cards.
+Implement a function `average_even_is_average_odd(<hand>)` that returns a Boolean indicating if the average of the cards at even indexes is the same as the average of the cards at odd indexes.
 
 
 ```python


### PR DESCRIPTION
Task 6 requires comparison of the averages of odd- and the even- positioned cards, but the instructions stated odd- and even- valued cards, which could have led to a confusion. Fun fact: the tests worked OK for both interpretations, due to the parities of values corresponding to the parities of indexes.